### PR TITLE
ci: update push trigger from master to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- Updates `.github/workflows/ci.yml` to trigger on pushes to `main` instead of `master` after the branch rename.

## Why
The default branch was renamed `master` → `main` as part of repo hygiene. GitHub auto-transferred branch protection and default-branch metadata, but workflow file content (the literal string `master` in the trigger) had to be updated by hand.