### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report
+it privately so it can be fixed before public disclosure.
+
+**Preferred:** use GitHub's [private vulnerability reporting](https://github.com/stultus/malayalam-factcheck-corpus/security/advisories/new).
+
+**Alternative:** email the maintainer at hrishi.kb@gmail.com with a
+description, reproduction steps, and impact assessment.
+
+You should expect an initial response within 7 days. Please do not file
+public issues for security problems.
+
+## Scope
+
+In scope:
+- The Python pipeline (`src/`, `scripts/`)
+- Project configuration (`pyproject.toml`, `configs/`)
+- Workflows under `.github/workflows`
+
+Out of scope:
+- Content of the source fact-check articles (we don't author or control them)
+- Vulnerabilities in upstream Python packages — please report those upstream
+- Issues with the resulting Parquet artefacts that aren't security-related (open a regular issue)
+
+## Note for data consumers
+
+If you find that the corpus contains content that should not be redistributed
+(copyright, takedown, personal data), please see [`TAKEDOWN.md`](TAKEDOWN.md)
+rather than this security policy.


### PR DESCRIPTION
## Summary
- Adds `SECURITY.md` with private vulnerability reporting policy.
- Points reporters to GitHub Private Vulnerability Reporting (now enabled) plus a fallback email.
- Defines scope (pipeline code + workflows) vs. out-of-scope (upstream packages, source-article content).
- Cross-references `TAKEDOWN.md` for non-security content concerns to avoid mis-routing reports.

## Why
Repo hygiene: gives security researchers a private channel and surfaces a "Security" tab in the GitHub UI.